### PR TITLE
Updated dependency versions, added shortcuts

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="11" />
+  </component>
+</project>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -12,14 +12,14 @@
       <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
     </remote-repository>
     <remote-repository>
-      <option name="id" value="BintrayJCenter" />
-      <option name="name" value="BintrayJCenter" />
-      <option name="url" value="https://jcenter.bintray.com/" />
-    </remote-repository>
-    <remote-repository>
       <option name="id" value="Google" />
       <option name="name" value="Google" />
       <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenRepo" />
+      <option name="name" value="MavenRepo" />
+      <option name="url" value="https://repo.maven.apache.org/maven2/" />
     </remote-repository>
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -3,6 +3,7 @@
   <component name="RunConfigurationProducerService">
     <option name="ignoredProducers">
       <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.AllInPackageGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestClassGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestMethodGradleConfigurationProducer" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 34
     defaultConfig {
         applicationId "com.jpwolfso.privdnsqt"
         minSdkVersion 28
-        targetSdkVersion 29
+        targetSdkVersion 34
         versionCode 6
         versionName '1.5'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -21,5 +21,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+    implementation 'com.android.support.constraint:constraint-layout:2.0.4'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         <activity
             android:name=".PrivateDnsConfigActivity"
             android:excludeFromRecents="true"
+            android:exported="true"
             android:label="@string/app_config">
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,16 @@
                 <category android:name="android.intent.category.LAUNCHER" />
                 <action android:name="android.intent.action.MAIN" />
             </intent-filter>
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
+        </activity>
+
+        <activity
+            android:name=".PrivateDnsShortcutActivity"
+            android:excludeFromRecents="true"
+            android:exported="true"
+            android:theme="@android:style/Theme.NoDisplay">
         </activity>
 
         <service

--- a/app/src/main/java/com/jpwolfso/privdnsqt/PrivateDnsCommon.java
+++ b/app/src/main/java/com/jpwolfso/privdnsqt/PrivateDnsCommon.java
@@ -1,0 +1,61 @@
+package com.jpwolfso.privdnsqt;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.provider.Settings;
+import android.widget.Toast;
+
+public class PrivateDnsCommon {
+    public static final String DNS_MODE_OFF = "off";
+    public static final String DNS_MODE_AUTO = "opportunistic";
+    public static final String DNS_MODE_ON = "hostname";
+
+    private Context context;
+
+    public PrivateDnsCommon(Context context) {
+        this.context = context;
+    }
+
+    public String getNextMode(String currentMode) {
+        final SharedPreferences toggleStates = context.getSharedPreferences("togglestates", Context.MODE_PRIVATE);
+
+        final boolean toggleOff = toggleStates.getBoolean("toggle_off", true);
+        final boolean toggleAuto = toggleStates.getBoolean("toggle_auto", true);
+        final boolean toggleOn = toggleStates.getBoolean("toggle_on", true);
+
+        String dnsprovider = Settings.Global.getString(context.getContentResolver(), "private_dns_specifier");
+        String newState = currentMode;
+
+        switch (currentMode.toLowerCase()) {
+            case DNS_MODE_ON:
+                if (toggleOff)
+                    newState = DNS_MODE_OFF;
+                else if (toggleAuto)
+                    newState = DNS_MODE_AUTO;
+                break;
+            case DNS_MODE_OFF:
+                if (toggleAuto)
+                    newState = DNS_MODE_AUTO;
+                else if (toggleOn)
+                    newState = DNS_MODE_ON;
+                break;
+            case DNS_MODE_AUTO:
+                if (dnsprovider != null && !dnsprovider.isEmpty()) {
+                    if (toggleOn)
+                        newState = DNS_MODE_ON;
+                    else if (toggleOff)
+                        newState = DNS_MODE_OFF;
+                } else {
+                    Toast.makeText(context, R.string.toast_no_dns, Toast.LENGTH_SHORT).show();
+                    newState = DNS_MODE_OFF;
+                }
+                break;
+        }
+        return newState;
+    }
+
+    public boolean hasPermission() {
+        return context.checkCallingOrSelfPermission("android.permission.WRITE_SECURE_SETTINGS") != PackageManager.PERMISSION_DENIED;
+    }
+}

--- a/app/src/main/java/com/jpwolfso/privdnsqt/PrivateDnsShortcutActivity.java
+++ b/app/src/main/java/com/jpwolfso/privdnsqt/PrivateDnsShortcutActivity.java
@@ -1,0 +1,76 @@
+package com.jpwolfso.privdnsqt;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+import android.provider.Settings;
+import android.widget.Toast;
+
+public class PrivateDnsShortcutActivity extends Activity {
+    private static final String ACTION_ENABLE_DNS = "com.jpwolfso.privdnsqt.ACTION_ENABLE";
+    private static final String ACTION_DISABLE_DNS = "com.jpwolfso.privdnsqt.ACTION_DISABLE";
+    private static final String ACTION_TOGGLE_DNS = "com.jpwolfso.privdnsqt.ACTION_TOGGLE";
+
+    private PrivateDnsCommon utils;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        utils = new PrivateDnsCommon(this);
+
+        Intent intent = getIntent();
+        if (intent != null) {
+            if (!hasPermission()) {
+                Toast.makeText(this, getString(R.string.toast_no_permission), Toast.LENGTH_LONG).show();
+                finish();
+                return;
+            }
+
+            String dnsMode = Settings.Global.getString(getContentResolver(), "private_dns_mode");
+            String dnsprovider = Settings.Global.getString(getContentResolver(), "private_dns_specifier");
+            String toastMsg = "";
+
+            switch (intent.getAction()) {
+                case ACTION_ENABLE_DNS:
+                    if (dnsprovider != null && !dnsprovider.isEmpty()) {
+                        dnsMode = PrivateDnsCommon.DNS_MODE_ON;
+                    } else {
+                        toastMsg = getString(R.string.toast_no_dns);
+                    }
+                    break;
+                case ACTION_DISABLE_DNS:
+                    dnsMode = PrivateDnsCommon.DNS_MODE_OFF;
+                    break;
+                case ACTION_TOGGLE_DNS:
+                    dnsMode = utils.getNextMode(dnsMode);
+                    break;
+            }
+
+            if (toastMsg.isEmpty()) {
+                switch (dnsMode) {
+                    case PrivateDnsCommon.DNS_MODE_OFF:
+                        toastMsg = getString(R.string.qt_off);
+                        break;
+                    case PrivateDnsCommon.DNS_MODE_ON:
+                        toastMsg = getString(R.string.dns_on) + ": " + dnsprovider;
+                        break;
+                    case PrivateDnsCommon.DNS_MODE_AUTO:
+                        toastMsg = getString(R.string.qt_auto);
+                        break;
+                }
+            }
+
+            Toast.makeText(this, toastMsg, Toast.LENGTH_SHORT).show();
+            Settings.Global.putString(getContentResolver(), "private_dns_mode", dnsMode);
+        }
+
+        finish();
+    }
+
+    public boolean hasPermission() {
+        return checkCallingOrSelfPermission("android.permission.WRITE_SECURE_SETTINGS") != PackageManager.PERMISSION_DENIED;
+    }
+
+}

--- a/app/src/main/java/com/jpwolfso/privdnsqt/PrivateDnsTileService.java
+++ b/app/src/main/java/com/jpwolfso/privdnsqt/PrivateDnsTileService.java
@@ -1,8 +1,5 @@
 package com.jpwolfso.privdnsqt;
 
-import android.content.Context;
-import android.content.SharedPreferences;
-import android.content.pm.PackageManager;
 import android.graphics.drawable.Icon;
 import android.provider.Settings;
 import android.service.quicksettings.Tile;
@@ -10,15 +7,15 @@ import android.service.quicksettings.TileService;
 import android.widget.Toast;
 
 public class PrivateDnsTileService extends TileService {
+    private PrivateDnsCommon utils;
 
-
-    public static String DNS_MODE_OFF = "off";
-    public static String DNS_MODE_AUTO = "opportunistic";
-    public static String DNS_MODE_ON = "hostname";
+    @Override
+    public void onCreate() {
+        utils = new PrivateDnsCommon(this);
+    }
 
     public void onTileAdded() {
         super.onTileAdded();
-
     }
 
     public void onTileRemoved() {
@@ -31,11 +28,11 @@ public class PrivateDnsTileService extends TileService {
         String dnsmode = Settings.Global.getString(getContentResolver(), "private_dns_mode");
         Tile tile = this.getQsTile();
 
-        if (dnsmode.equalsIgnoreCase(DNS_MODE_OFF)) {
+        if (dnsmode.equalsIgnoreCase(PrivateDnsCommon.DNS_MODE_OFF)) {
             refreshTile(tile, Tile.STATE_INACTIVE, getString(R.string.qt_off), R.drawable.ic_dnsoff);
-        } else if (dnsmode.equalsIgnoreCase(DNS_MODE_AUTO)) {
+        } else if (dnsmode.equalsIgnoreCase(PrivateDnsCommon.DNS_MODE_AUTO)) {
             refreshTile(tile, Tile.STATE_ACTIVE, getString(R.string.qt_auto), R.drawable.ic_dnsauto);
-        } else if (dnsmode.equalsIgnoreCase(DNS_MODE_ON)) {
+        } else if (dnsmode.equalsIgnoreCase(PrivateDnsCommon.DNS_MODE_ON)) {
             String dnsprovider = Settings.Global.getString(getContentResolver(), "private_dns_specifier");
             if ((dnsprovider != null)) {
                 refreshTile(tile, Tile.STATE_ACTIVE, dnsprovider, R.drawable.ic_dnson);
@@ -52,58 +49,31 @@ public class PrivateDnsTileService extends TileService {
     public void onClick() {
         super.onClick();
 
-        final SharedPreferences togglestates = getSharedPreferences("togglestates", Context.MODE_PRIVATE);
-
-        final Boolean toggleoff = togglestates.getBoolean("toggle_off", true);
-        final Boolean toggleauto = togglestates.getBoolean("toggle_auto", true);
-        final Boolean toggleon = togglestates.getBoolean("toggle_on", true);
-
         String dnsprovider = Settings.Global.getString(getContentResolver(), "private_dns_specifier");
+        String dnsMode = Settings.Global.getString(getContentResolver(), "private_dns_mode");
+        String newMode = utils.getNextMode(dnsMode);
+        Tile tile = this.getQsTile();
 
-        if (hasPermission()) {
-            String dnsmode = Settings.Global.getString(getContentResolver(), "private_dns_mode");
-            Tile tile = this.getQsTile();
-            if (dnsmode.equalsIgnoreCase(DNS_MODE_OFF)) {
-                if (toggleauto) {
-                    changeTileState(tile, Tile.STATE_ACTIVE, getString(R.string.qt_auto), R.drawable.ic_dnsauto, DNS_MODE_AUTO);
-                } else if (toggleon) {
-                    changeTileState(tile, Tile.STATE_ACTIVE, dnsprovider, R.drawable.ic_dnson, DNS_MODE_ON);
-                }
-            } else if (dnsmode.equalsIgnoreCase(DNS_MODE_AUTO)) {
-                if (dnsprovider != null) {
-                    if (toggleon) {
-                        changeTileState(tile, Tile.STATE_ACTIVE, dnsprovider, R.drawable.ic_dnson, DNS_MODE_ON);
-                    } else if (toggleoff) {
-                        changeTileState(tile, Tile.STATE_INACTIVE, getString(R.string.qt_off), R.drawable.ic_dnsoff, DNS_MODE_OFF);
-                    }
-                } else {
-                    if (toggleoff) {
-                        changeTileState(tile, Tile.STATE_INACTIVE, getString(R.string.qt_off), R.drawable.ic_dnsoff, DNS_MODE_OFF);
-                    }
-                }
-            } else if (dnsmode.equals(DNS_MODE_ON)) {
-                if (toggleoff) {
-                    changeTileState(tile, Tile.STATE_INACTIVE, getString(R.string.qt_off), R.drawable.ic_dnsoff, DNS_MODE_OFF);
-                } else if (toggleauto) {
-                    changeTileState(tile, Tile.STATE_ACTIVE, getString(R.string.qt_auto), R.drawable.ic_dnsauto, DNS_MODE_AUTO);
-                }
+        if (utils.hasPermission()) {
+            switch (newMode) {
+                case PrivateDnsCommon.DNS_MODE_ON:
+                    changeTileState(tile, Tile.STATE_ACTIVE, dnsprovider, R.drawable.ic_dnson, PrivateDnsCommon.DNS_MODE_ON);
+                    break;
+                case PrivateDnsCommon.DNS_MODE_OFF:
+                    changeTileState(tile, Tile.STATE_INACTIVE, getString(R.string.qt_off), R.drawable.ic_dnsoff, PrivateDnsCommon.DNS_MODE_OFF);
+                    break;
+                case PrivateDnsCommon.DNS_MODE_AUTO:
+                    changeTileState(tile, Tile.STATE_ACTIVE, getString(R.string.qt_auto), R.drawable.ic_dnsauto, PrivateDnsCommon.DNS_MODE_AUTO);
+                    break;
             }
-
-        } else if (!(hasPermission())) {
-            Toast.makeText(this, getString(R.string.toast_no_permission), Toast.LENGTH_SHORT).show();
+        } else {
+            Toast.makeText(this, getString(R.string.toast_no_permission), Toast.LENGTH_LONG).show();
         }
     }
 
-    public boolean hasPermission() {
-        return checkCallingOrSelfPermission("android.permission.WRITE_SECURE_SETTINGS") != PackageManager.PERMISSION_DENIED;
-    }
-
     public void changeTileState(Tile tile, int state, String label, int icon, String dnsmode) {
-        tile.setLabel(label);
-        tile.setState(state);
-        tile.setIcon(Icon.createWithResource(this, icon));
         Settings.Global.putString(getContentResolver(), "private_dns_mode", dnsmode);
-        tile.updateTile();
+        refreshTile(tile, state, label, icon);
     }
 
     public void refreshTile(Tile tile, int state, String label, int icon) {
@@ -112,6 +82,4 @@ public class PrivateDnsTileService extends TileService {
         tile.setIcon(Icon.createWithResource(this, icon));
         tile.updateTile();
     }
-
-
 }

--- a/app/src/main/res/drawable/ic_dnsauto.xml
+++ b/app/src/main/res/drawable/ic_dnsauto.xml
@@ -1,7 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:tint="#FFFFFF"
     android:viewportWidth="24.0"
     android:viewportHeight="24.0">
     <path

--- a/app/src/main/res/drawable/ic_dnsoff.xml
+++ b/app/src/main/res/drawable/ic_dnsoff.xml
@@ -1,7 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:tint="#FFFFFF"
     android:viewportWidth="24.0"
     android:viewportHeight="24.0">
     <path

--- a/app/src/main/res/drawable/ic_dnson.xml
+++ b/app/src/main/res/drawable/ic_dnson.xml
@@ -1,7 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:tint="#FFFFFF"
     android:viewportWidth="24.0"
     android:viewportHeight="24.0">
     <path

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -15,4 +15,7 @@
     <string name="app_info">App info</string>
     <string name="view_fdroid">View on F-Droid</string>
     <string name="help">Help</string>
+    <string name="shortcut_enable">Enable Private DNS</string>
+    <string name="shortcut_disable">Disable Private DNS</string>
+    <string name="shortcut_toggle">Toggle Private DNS</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -15,4 +15,7 @@
     <string name="help">Aide</string>
     <string name="app_info">Info sur l\'app</string>
     <string name="view_fdroid">Afficher les détails sur F-Droid</string>
+    <string name="shortcut_enable">Activer le DNS privé</string>
+    <string name="shortcut_disable">Désactiver le DNS privé</string>
+    <string name="shortcut_toggle">Basculer vers le DNS privé</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,4 +14,7 @@
     <string name="app_info">App info</string>
     <string name="view_fdroid">View on F-Droid</string>
     <string name="help">Help</string>
+    <string name="shortcut_enable">Enable Private DNS</string>
+    <string name="shortcut_disable">Disable Private DNS</string>
+    <string name="shortcut_toggle">Toggle Private DNS</string>
 </resources>

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:enabled="true"
+        android:icon="@drawable/ic_dnson"
+        android:shortcutId="enable"
+        android:shortcutShortLabel="@string/shortcut_enable">
+        <intent
+            android:action="com.jpwolfso.privdnsqt.ACTION_ENABLE"
+            android:targetClass="com.jpwolfso.privdnsqt.PrivateDnsShortcutActivity"
+            android:targetPackage="com.jpwolfso.privdnsqt" />
+    </shortcut>
+    <shortcut
+        android:enabled="true"
+        android:icon="@drawable/ic_dnsoff"
+        android:shortcutId="disable"
+        android:shortcutShortLabel="@string/shortcut_disable">
+        <intent
+            android:action="com.jpwolfso.privdnsqt.ACTION_DISABLE"
+            android:targetClass="com.jpwolfso.privdnsqt.PrivateDnsShortcutActivity"
+            android:targetPackage="com.jpwolfso.privdnsqt" />
+    </shortcut>
+    <shortcut
+        android:enabled="true"
+        android:icon="@drawable/ic_dnsauto"
+        android:shortcutId="toggle"
+        android:shortcutShortLabel="@string/shortcut_toggle">
+        <intent
+            android:action="com.jpwolfso.privdnsqt.ACTION_TOGGLE"
+            android:targetClass="com.jpwolfso.privdnsqt.PrivateDnsShortcutActivity"
+            android:targetPackage="com.jpwolfso.privdnsqt" />
+    </shortcut>
+</shortcuts>

--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,10 @@
 buildscript {
     repositories {
         google()
-        jcenter()
-        
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -17,8 +16,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
-        
+        mavenCentral()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
This RP adds the ability to turn the Private DNS feature on / off with app shortcuts.
These enable automation of the settings using routines on Galaxy Smartphones.

Tested on Android 10 and 14.
(Probably) Fixes #17 